### PR TITLE
Connection handler exposed

### DIFF
--- a/mqtt_transport.go
+++ b/mqtt_transport.go
@@ -68,7 +68,7 @@ func (mh *MqttTransport) SetMessageHandler(msgHandler MessageHandler) {
 
 // OnConnectionLost Handler, handling connection state outside of the lib
 func (mh *MqttTransport) SetOnConnectionLostHandler(connHandler MQTT.ConnectionLostHandler) {
-	mh.onConnectionLost = connHandler
+	mh.SetOnConnectionLostHandler(connHandler)
 }
 
 // RegisterChannel should be used if new message has to be send to channel instead of callback.


### PR DESCRIPTION
It would be very useful and fail proof wise to have this handler exposed to an app who's using this lib. The very first use case I got is from a kind-owl app, I want to be able to reconnect after the connection is lost. Even if MQTT broker is on the localhost, I have to ensure that my service will reconnect if something happens to the broker. Exposing this costs nothing but adds some more security and stability.