### PR TITLE
Add Options() and SetOptions()

### DIFF
--- a/mqtt_transport.go
+++ b/mqtt_transport.go
@@ -89,6 +89,10 @@ func (mh *MqttTransport) Options() *MQTT.ClientOptions {
 	return mh.mqttOptions
 }
 
+func (mh *MqttTransport) SetOptions(options *MQTT.ClientOptions) {
+	mh.client = MQTT.NewClient(options)
+}
+
 type MessageHandler func(topic string, addr *Address, iotMsg *FimpMessage, rawPayload []byte)
 
 // NewMqttTransport constructor. serverUri="tcp://localhost:1883"

--- a/mqtt_transport.go
+++ b/mqtt_transport.go
@@ -85,6 +85,10 @@ func (mh *MqttTransport) SetCertDir(certDir string) {
 	mh.certDir = certDir
 }
 
+func (mh *MqttTransport) Options() *MQTT.ClientOptions {
+	return mh.mqttOptions
+}
+
 type MessageHandler func(topic string, addr *Address, iotMsg *FimpMessage, rawPayload []byte)
 
 // NewMqttTransport constructor. serverUri="tcp://localhost:1883"


### PR DESCRIPTION
Get Option to set custom onConnectionLost handler and manipulate other parameters

```
	options := client.Options()
	options.SetConnectionLostHandler(onConnectionLost)
	client.SetOptions(options)