### PR TITLE
Fix crash on incorrect payloadType

### DIFF
--- a/mqtt_transport.go
+++ b/mqtt_transport.go
@@ -462,8 +462,8 @@ func (mh *MqttTransport) handleIncomingMessage(msg MQTT.Message) {
 		fimpMsg, err = mh.compressor.DecompressFimpMsg(msg.Payload())
 	default:
 		// This means unknown binary payload , for instance compressed message
-		log.Errorf("[fimpgo] Unknown PayloadType=%s topic=%s", addr.PayloadType, topic)
-		return
+		log.Warnf("[fimpgo] Unknown PayloadType=%s topic=%s", addr.PayloadType, topic)
+		fimpMsg, err = NewMessageFromBytes(msg.Payload())
 	}
 
 	if err != nil {

--- a/mqtt_transport.go
+++ b/mqtt_transport.go
@@ -463,12 +463,12 @@ func (mh *MqttTransport) handleIncomingMessage(msg MQTT.Message) {
 	default:
 		// This means unknown binary payload , for instance compressed message
 		log.Warnf("[fimpgo] Unknown PayloadType=%s topic=%s", addr.PayloadType, topic)
-		fimpMsg, err = NewMessageFromBytes(msg.Payload())
+		return
 	}
 
 	if err != nil {
-		log.Trace(string(msg.Payload()))
 		log.Errorf("[fimpgo] Processing payload from topic=%s err: %v", topic, err)
+		log.Tracef("[fimpgo] Payload preview (len=%d): %.100s", len(msg.Payload()), msg.Payload())
 		return
 	}
 

--- a/mqtt_transport.go
+++ b/mqtt_transport.go
@@ -462,17 +462,18 @@ func (mh *MqttTransport) handleIncomingMessage(msg MQTT.Message) {
 		fimpMsg, err = mh.compressor.DecompressFimpMsg(msg.Payload())
 	default:
 		// This means unknown binary payload , for instance compressed message
-		log.Trace("<MqttAd> Unknown binary payload :", addr.PayloadType)
+		log.Errorf("[fimpgo] Unknown PayloadType=%s topic=%s", addr.PayloadType, topic)
+		return
+	}
+
+	if err != nil {
+		log.Trace(string(msg.Payload()))
+		log.Errorf("[fimpgo] Processing payload from topic=%s err: %v", topic, err)
+		return
 	}
 
 	if mh.msgHandler != nil {
-		if err == nil {
-			mh.msgHandler(topic, addr, fimpMsg, msg.Payload())
-		} else {
-			log.Trace(string(msg.Payload()))
-			log.Error("<MqttAd> Error processing payload :", err)
-			return
-		}
+		mh.msgHandler(topic, addr, fimpMsg, msg.Payload())
 	}
 
 	mh.channelRegMux.Lock()


### PR DESCRIPTION
- Adds early return when an unknown PayloadType is encountered, preventing nil pointer dereferences
- Refactors error handling to check errors before invoking msgHandler
- Improves error logging with more context (topic and PayloadType information)