### PR TITLE
Add ServiceName constructor for typed service names

### DIFF
--- a/fimptype/service_name.go
+++ b/fimptype/service_name.go
@@ -28,3 +28,8 @@ const (
 func (s ServiceNameT) Str() string {
 	return string(s)
 }
+
+// ServiceName converts a plain string to a typed FIMP service name.
+func ServiceName(s string) ServiceNameT {
+	return ServiceNameT(s)
+}


### PR DESCRIPTION
## What

Adds a small constructor to `fimptype`:

```go
// ServiceName converts a plain string to a typed FIMP service name.
func ServiceName(s string) ServiceNameT {
	return ServiceNameT(s)
}
```

## Why

`ServiceNameT` already has `Str()` for the typed→string direction, but the string→typed direction requires a raw cast at every call site (`fimptype.ServiceNameT(service)`). Services and adapters that build FIMP messages from dynamic service names (e.g. kind-owl's notification tests and message builders) end up defining the same local helper repeatedly. Providing it in `fimptype` gives one canonical, readable spelling: `fimptype.ServiceName("kind_owl")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)